### PR TITLE
[FIX/pk] 쿠키에 pk값인 id 추가

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -80,7 +80,6 @@ module.exports = {
     );
     request.on('close', () => {
       console.log('Sent message to microservice.');
-      res.redirect("/");
     });
     request.on('error', (err) => {
       console.log('Failed to send message');

--- a/controllers/residentController.js
+++ b/controllers/residentController.js
@@ -14,7 +14,8 @@ module.exports = {
       headers: {
         ...
         req.headers,
-        auth: res.locals.auth
+        auth: res.locals.auth,
+        id: res.locals.id
       }
     }
     const forwardRequest = http.request(
@@ -48,7 +49,8 @@ module.exports = {
       headers: {
         ...
         req.headers,
-        auth: res.locals.auth
+        auth: res.locals.auth,
+        id: res.locals.id
       }
     }
     const forwardRequest = http.request(
@@ -82,7 +84,8 @@ module.exports = {
       headers: {
         ...
         req.headers,
-        auth: res.locals.auth
+        auth: res.locals.auth,
+        id: res.locals.id
       }
     }
     const forwardRequest = http.request(

--- a/main.js
+++ b/main.js
@@ -28,10 +28,12 @@ app.use((req, res, next) => {
     if (decoded.userId == null)
       return res.render('notFound.ejs', {message: "로그인이 필요합니다"});
       res.locals.auth = decoded.userId;
+      res.locals.id = decoded.id;
       res.locals.userType = req.cookies.userType;
       res.locals.is_admin = adminControl.getAdmin(decoded.userId);
   } catch (error) {
     res.locals.auth = "";
+    res.locals.id = "";
     res.locals.userType = "";
     res.locals.is_admin = "";
   }


### PR DESCRIPTION
**Description**
- 기존에는 쿠키에 username만 jwt token으로 저장되었습니다
- pk 값인 id가 필요한 경우가 많은 것 같아 id도 추가로 저장되게 되었습니다
- 예시
```
{
    userId: "ywonchae1",
    id: 3,
}
```
- 이 값은 stop_bang_main 컨트롤러에서 각각 `res.locals.auth`, `res.locals.id`로 접근할 수 있습니다.
- 모든 요청이 아래 코드를 거치기 때문에 그렇습니다.
```js
// stop_bang_main의 main.js 코드 중
app.use((req, res, next) => {
  try {
    const decoded = jwt.verify(
      req.cookies.authToken,
      process.env.JWT_SECRET_KEY
    );
    if (decoded.userId == null)
      return res.render('notFound.ejs', {message: "로그인이 필요합니다"});
      res.locals.auth = decoded.userId;
      res.locals.id = decoded.id; // 추가되었습니다
      res.locals.userType = req.cookies.userType;
      res.locals.is_admin = adminControl.getAdmin(decoded.userId);
  } catch (error) {
    res.locals.auth = "";
    res.locals.id = ""; // 추가되었습니다
    res.locals.userType = "";
    res.locals.is_admin = "";
  }
  next();
})
```